### PR TITLE
Added user/update api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Or install it yourself as:
 
 - user/create
 - user/custcreate
+- user/update
 - user/list
 - meeting/create
 - meeting/delete

--- a/lib/zoomus/actions/user.rb
+++ b/lib/zoomus/actions/user.rb
@@ -25,6 +25,12 @@ module Zoomus
         Utils.parse_response self.class.post('/user/custcreate', :query => options)
       end
 
+      def user_update(*args)
+        options = Utils.extract_options!(args)
+        Utils.require_params([:id], options)
+        Utils.parse_response self.class.post('/user/update', :query => options)
+      end
+
       Utils.define_bang_methods(self)
 
     end

--- a/spec/fixtures/user_update.json
+++ b/spec/fixtures/user_update.json
@@ -1,0 +1,4 @@
+{
+  "id": "eIimBAXqSrWOcB_EOIXTog",
+  "updated_at": "2013-02-05T11:23:58Z"
+}

--- a/spec/lib/zoomus/actions/user/update_spec.rb
+++ b/spec/lib/zoomus/actions/user/update_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Zoomus::Actions::User do
+
+  before :all do
+    @zc = zoomus_client
+    @args = {:id => "eIimBAXqSrWOcB_EOIXTog",
+             :first_name => "Bar",
+             :last_name => "Foo"}
+  end
+
+  describe "#user_update action" do
+    before :each do
+      stub_request(
+        :post,
+        zoomus_url("/user/update")
+      ).to_return(:body => json_response("user_update"))
+    end
+
+    it "requires id param" do
+      expect{@zc.user_update(filter_key(@args, :id))}.to raise_error(ArgumentError)
+    end
+
+    it "returns a hash" do
+      expect(@zc.user_update(@args)).to be_kind_of(Hash)
+    end
+
+    it "returns id and updated_at" do
+      res = @zc.user_update(@args)
+
+      expect(res["id"]).to eq(@args[:id])
+      expect(res).to have_key("updated_at")
+    end
+  end
+
+  describe "#user_update! action" do
+    before :each do
+      stub_request(
+        :post,
+        zoomus_url("/user/update")
+      ).to_return(:body => json_response("error"))
+    end
+
+    it "raises Zoomus::Error exception" do
+      expect {
+        @zc.user_update!(@args)
+      }.to raise_error(Zoomus::Error)
+    end
+  end
+end

--- a/spec/lib/zoomus/utils_spec.rb
+++ b/spec/lib/zoomus/utils_spec.rb
@@ -20,7 +20,7 @@ describe Zoomus::Utils do
 
     it "does not raise Zoomus::Error if error is not present" do
       response = {}
-      expect{Utils.raise_if_error!(response)}.to_not raise_error(Zoomus::Error)
+      expect{Utils.raise_if_error!(response)}.to_not raise_error
     end
   end
 
@@ -30,7 +30,7 @@ describe Zoomus::Utils do
     end
 
     it "does not raise ArgumentError if the param is present" do
-      expect{Utils.require_params(:foo, {:foo => 'foo'})}.to_not raise_error(ArgumentError)
+      expect{Utils.require_params(:foo, {:foo => 'foo'})}.to_not raise_error
     end
   end
 


### PR DESCRIPTION
Hi,

I've added the user/update endpoint to the gem.

Besides that I've fixed an issue with newer spec versions when calling to_not + raise_error with a specific Error class as a parameter, as described here: https://github.com/rspec/rspec-expectations/issues/231

In case you would rather stick to having to_not raise_error(SpecificError) we might need to specific an older version of spec on the Gemfile to avoid failure for people with newer rspec versions.

Please verify,

Thanks a lot!