### PR TITLE
Meeting update does not require topic nor type for successful update

### DIFF
--- a/lib/zoomus/actions/meeting.rb
+++ b/lib/zoomus/actions/meeting.rb
@@ -18,7 +18,7 @@ module Zoomus
 
       def meeting_update(*args)
         options = Utils.extract_options!(args)
-        Utils.require_params([:id, :host_id, :topic, :type], options)
+        Utils.require_params([:id, :host_id], options)
         Utils.process_datetime_params!(:start_time, options)
         Utils.parse_response self.class.post("/meeting/update", :query => options)
       end

--- a/spec/lib/zoomus/actions/meeting/update_spec.rb
+++ b/spec/lib/zoomus/actions/meeting/update_spec.rb
@@ -5,9 +5,7 @@ describe Zoomus::Actions::Meeting do
   before :all do
     @zc = zoomus_client
     @args = {:host_id => 'ufR93M2pRyy8ePFN92dttq',
-             :id => '252482092',
-             :type => 0,
-             :topic => 'Foo'}
+             :id => '252482092'}
   end
 
   describe "#meeting_update action" do
@@ -20,14 +18,6 @@ describe Zoomus::Actions::Meeting do
 
     it "requires a 'host_id' argument" do
       expect{@zc.meeting_update(filter_key(@args, :host_id))}.to raise_error(ArgumentError)
-    end
-
-    it "requires a 'topic' argument" do
-      expect{@zc.meeting_update(filter_key(@args, :topic))}.to raise_error(ArgumentError)
-    end
-
-    it "requires a 'type' argument" do
-      expect{@zc.meeting_update(filter_key(@args, :type))}.to raise_error(ArgumentError)
     end
 
     it "requires a 'id' argument" do


### PR DESCRIPTION
According to the documentation, only id and host_id are required parameters to update a meeting.

https://support.zoom.us/hc/en-us/articles/201363053-REST-Meeting-API