### PR TITLE
Handle timeouts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'httparty', '0.13.3'
-gem 'json', '1.8.2'
-group :test do
-  gem 'rspec'
-  gem 'webmock'
-end
+gemspec

--- a/lib/zoomus.rb
+++ b/lib/zoomus.rb
@@ -1,3 +1,5 @@
+$:.unshift File.dirname(__FILE__)
+
 require 'zoomus/utils'
 require 'zoomus/actions/user'
 require 'zoomus/actions/meeting'

--- a/lib/zoomus.rb
+++ b/lib/zoomus.rb
@@ -13,7 +13,8 @@ module Zoomus
       @configuration ||= Configuration.new
       Zoomus::Client.new(
         :api_key => @configuration.api_key,
-        :api_secret => @configuration.api_secret
+        :api_secret => @configuration.api_secret,
+        :timeout => @configuration.timeout
       )
     end
 
@@ -24,10 +25,11 @@ module Zoomus
   end
 
   class Configuration
-    attr_accessor :api_key, :api_secret
+    attr_accessor :api_key, :api_secret, :timeout
 
     def initialize
       @api_key = @api_secret = 'xxx'
+      @timeout = 15
     end
   end
 end

--- a/lib/zoomus/client.rb
+++ b/lib/zoomus/client.rb
@@ -21,6 +21,7 @@ module Zoomus
         :api_key    => options[:api_key],
         :api_secret => options[:api_secret]
       )
+      self.class.default_timeout(options[:timeout])
     end
   end
 end

--- a/lib/zoomus/error.rb
+++ b/lib/zoomus/error.rb
@@ -1,3 +1,4 @@
 module Zoomus
   class Error < StandardError; end
+  class GatewayTimeout < StandardError; end
 end

--- a/lib/zoomus/utils.rb
+++ b/lib/zoomus/utils.rb
@@ -35,7 +35,12 @@ module Zoomus
       def define_bang_methods(klass)
         klass.instance_methods.each do |m|
           klass.send(:define_method, "#{m}!") do |*args|
-            Utils.raise_if_error! send(m, *args)
+            begin
+              response = send(m, *args)
+              Utils.raise_if_error!(response)
+            rescue Net::OpenTimeout, Net::ReadTimeout, Timeout::Error => _e
+              raise ::Zoomus::GatewayTimeout.new
+            end
           end
         end
       end

--- a/spec/lib/zoomus/client_spec.rb
+++ b/spec/lib/zoomus/client_spec.rb
@@ -10,6 +10,25 @@ describe Zoomus::Client do
     it "must have the base url set to Zoomus API endpoint" do
       expect(Zoomus::Client.base_uri).to eq('https://api.zoom.us/v1')
     end
+
+    it "must have a default timeout set to 15 seconds" do
+      Zoomus.configure do |config|
+        config.api_key = 'xxx'
+        config.api_secret = 'xxx'
+      end
+      Zoomus.new
+      expect(Zoomus::Client.default_options[:timeout]).to eq(15)
+    end
+
+    it "must get the timeout from the configuration" do
+      Zoomus.configure do |config|
+        config.api_key = 'xxx'
+        config.api_secret = 'xxx'
+        config.timeout = 20
+      end
+      Zoomus.new
+      expect(Zoomus::Client.default_options[:timeout]).to eq(20)
+    end
   end
 
   describe "constructor" do

--- a/spec/lib/zoomus/client_spec.rb
+++ b/spec/lib/zoomus/client_spec.rb
@@ -37,7 +37,7 @@ describe Zoomus::Client do
     end
 
     it "creates instance of Zoomus::Client if api_key and api_secret is provided" do
-      expect(Zoomus::Client.new(:api_key => "xxx", :api_secret => "xxx")).to be_an_instance_of(Zoomus::Client)
+      expect(Zoomus::Client.new(:api_key => "xxx", :api_secret => "xxx", :timeout => 15)).to be_an_instance_of(Zoomus::Client)
     end
   end
 end

--- a/spec/lib/zoomus/utils_spec.rb
+++ b/spec/lib/zoomus/utils_spec.rb
@@ -53,4 +53,19 @@ describe Zoomus::Utils do
                :bar => "2000-01-01T20:15:01Z"})
     end
   end
+
+  describe '#define_bang_methods' do
+    before :each do
+      stub_request(:post, zoomus_url("/user/custcreate")).to_timeout
+    end
+
+    it "raises Zoomus::GatewayTimeout on timeout" do
+      args = {:email => "foo@bar.com",
+               :first_name => "Foo",
+               :last_name => "Bar",
+               :type => 1}
+
+      expect { zoomus_client.user_custcreate!(args) }.to raise_error(Zoomus::GatewayTimeout)
+    end
+  end
 end

--- a/zoomus.gemspec
+++ b/zoomus.gemspec
@@ -2,8 +2,12 @@
 
 Gem::Specification.new do |gem|
 
-  gem.add_dependency 'httparty', '0.13.3'
-  gem.add_dependency 'json', '1.8.2'
+  gem.add_dependency 'httparty', '~> 0.13'
+  gem.add_dependency 'json', '~> 1.8'
+
+  gem.add_development_dependency 'byebug'
+  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'webmock'
 
   gem.authors       = ['Maxim Colls']
   gem.email         = ['collsmaxim@gmail.com']


### PR DESCRIPTION
We get a recurring HTTP 504 error from Zoom's API that we need to defend from. I add here a 15 seconds default timeout using HTTParty's `default_timeout` and add a `timeout` configuration attribute for the consumers to use.