### PR TITLE
allow ruby 2.4 default json gem version

### DIFF
--- a/zoomus.gemspec
+++ b/zoomus.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |gem|
 
   gem.add_dependency 'httparty', '~> 0.13'
-  gem.add_dependency 'json', '~> 1.8'
+  gem.add_dependency 'json', '>= 1.8'
 
   gem.add_development_dependency 'byebug'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
ruby 2.4 has json packaged as a system gem, this change will allow the system gem to be used.